### PR TITLE
Added support for Async methods, fixed usage of HttpClient, exposed XElement for usage by consumers

### DIFF
--- a/FeedReader.Tests/FeedReader.Tests.csproj
+++ b/FeedReader.Tests/FeedReader.Tests.csproj
@@ -54,6 +54,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="FeedReaderTest.cs" />
+    <Compile Include="ItunesTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="FullParseTest.cs" />
   </ItemGroup>
@@ -122,6 +123,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Feeds\Rss20IndianExpress.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Feeds\Rss20ItunesSample.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Feeds\Rss20JapanTimes.xml">

--- a/FeedReader.Tests/FeedReaderTest.cs
+++ b/FeedReader.Tests/FeedReaderTest.cs
@@ -173,7 +173,9 @@ namespace CodeHollow.FeedReader.Tests
             Assert.IsTrue(feed.Items.Count > 0);
         }
 
+        // The timedoctor feed does not exist anymore
         [TestMethod]
+        [Ignore]
         public void TestReadTimeDoctor()
         {
             var feed = FeedReader.Read("https://blog.timedoctor.com/feed/");

--- a/FeedReader.Tests/FeedReaderTest.cs
+++ b/FeedReader.Tests/FeedReaderTest.cs
@@ -173,12 +173,10 @@ namespace CodeHollow.FeedReader.Tests
             Assert.IsTrue(feed.Items.Count > 0);
         }
 
-        // The timedoctor feed does not exist anymore
         [TestMethod]
-        [Ignore]
         public void TestReadTimeDoctor()
         {
-            var feed = FeedReader.Read("https://blog.timedoctor.com/feed/");
+            var feed = FeedReader.Read("https://www.timedoctor.com/blog/feed/");
             Assert.AreEqual("Time Doctor", feed.Title);
             Assert.IsTrue(feed.Items.Count > 0);
         }

--- a/FeedReader.Tests/Feeds/Rss20ItunesSample.xml
+++ b/FeedReader.Tests/Feeds/Rss20ItunesSample.xml
@@ -1,0 +1,75 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title>All About Everything</title>
+    <link>http://www.example.com/podcasts/everything/index.html</link>
+    <language>en-us</language>
+    <copyright>&#x2117; &amp; &#xA9; 2014 John Doe &amp; Family</copyright>
+    <itunes:subtitle>A show about everything</itunes:subtitle>
+    <itunes:author>John Doe</itunes:author>
+    <itunes:summary>All About Everything is a show about everything. Each week we dive into any subject known to man and talk about it as much as we can. Look for our podcast in the Podcasts app or in the iTunes Store</itunes:summary>
+    <description>All About Everything is a show about everything. Each week we dive into any subject known to man and talk about it as much as we can. Look for our podcast in the Podcasts app or in the iTunes Store</description>
+    <itunes:owner>
+      <itunes:name>John Doe</itunes:name>
+      <itunes:email>john.doe@example.com</itunes:email>
+    </itunes:owner>
+    <itunes:image href="http://example.com/podcasts/everything/AllAboutEverything.jpg"/>
+    <itunes:category text="Technology">
+      <itunes:category text="Gadgets"/>
+    </itunes:category>
+    <itunes:category text="TV &amp; Film"/>
+    <itunes:category text="Arts">
+      <itunes:category text="Food"/>
+    </itunes:category>
+    <itunes:explicit>no</itunes:explicit>
+    <item>
+      <title>Shake Shake Shake Your Spices</title>
+      <itunes:author>John Doe</itunes:author>
+      <itunes:subtitle>A short primer on table spices</itunes:subtitle>
+      <itunes:summary><![CDATA[This week we talk about <a href="https://itunes/apple.com/us/book/antique-trader-salt-pepper/id429691295?mt=11">salt and pepper shakers</a>, comparing and contrasting pour rates, construction materials, and overall aesthetics. Come and join the party!]]></itunes:summary>
+      <itunes:image href="http://example.com/podcasts/everything/AllAboutEverything/Episode1.jpg"/>
+      <enclosure length="8727310" type="audio/x-m4a" url="http://example.com/podcasts/everything/AllAboutEverythingEpisode3.m4a"/>
+      <guid>http://example.com/podcasts/archive/aae20140615.m4a</guid>
+      <pubDate>Tue, 08 Mar 2016 12:00:00 GMT</pubDate>
+      <itunes:duration>07:04</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>Socket Wrench Shootout</title>
+      <itunes:author>Jane Doe</itunes:author>
+      <itunes:subtitle>Comparing socket wrenches is fun!</itunes:subtitle>
+      <itunes:summary>This week we talk about metric vs. Old English socket wrenches. Which one is better? Do you really need both? Get all of your answers here.</itunes:summary>
+      <itunes:image href="http://example.com/podcasts/everything/AllAboutEverything/Episode2.jpg"/>
+      <enclosure length="5650889" type="video/mp4" url="http://example.com/podcasts/everything/AllAboutEverythingEpisode2.mp4"/>
+      <guid>http://example.com/podcasts/archive/aae20140608.mp4</guid>
+      <pubDate>Wed, 09 Mar 2016 13:00:00 EST</pubDate>
+      <itunes:duration>04:34</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>The Best Chili</title>
+      <itunes:author>Jane Doe</itunes:author>
+      <itunes:subtitle>Jane and Eric</itunes:subtitle>
+      <itunes:summary>This week we talk about the best Chili in the world. Which chili is better?</itunes:summary>
+      <itunes:image href="http://example.com/podcasts/everything/AllAboutEverything/Episode3.jpg"/>
+      <enclosure length="5650889" type="video/x-m4v" url="http://example.com/podcasts/everything/AllAboutEverythingEpisode2.m4v"/>
+      <guid>http://example.com/podcasts/archive/aae20140697.m4v</guid>
+      <pubDate>Thu, 10 Mar 2016 02:00:00 -0700</pubDate>
+      <itunes:duration>04:34</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:isClosedCaptioned>Yes</itunes:isClosedCaptioned>
+    </item>
+    <item>
+      <title>Red,Whine, &amp; Blue</title>
+      <itunes:author>Various</itunes:author>
+      <itunes:subtitle>Red + Blue != Purple</itunes:subtitle>
+      <itunes:summary>This week we talk about surviving in a Red state if you are a Blue person. Or vice versa.</itunes:summary>
+      <itunes:image href="http://example.com/podcasts/everything/AllAboutEverything/Episode4.jpg"/>
+      <enclosure length="498537" type="audio/mpeg" url="http://example.com/podcasts/everything/AllAboutEverythingEpisode4.mp3"/>
+      <guid>http://example.com/podcasts/archive/aae20140601.mp3</guid>
+      <pubDate>Fri, 11 Mar 2016 01:15:00 +3000</pubDate>
+      <itunes:duration>03:59</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+  </channel>
+</rss>

--- a/FeedReader.Tests/FullParseTest.cs
+++ b/FeedReader.Tests/FullParseTest.cs
@@ -263,10 +263,6 @@ namespace CodeHollow.FeedReader.Tests
         }
 
         [TestMethod]
-        [Ignore]
-        // this test is invalid since RSS 2.0 feeds must follow the 
-        // http://www.faqs.org/rfcs/rfc822.html RFC822 for Date and Time formats
-        // therefore a date specified in german is not a valid date for an RSS feed
         public void TestRss20ParseContentWindGerman()
         {
             var feed = (Rss20Feed)FeedReader.ReadFromFile("Feeds/Rss20ContentWindCom.xml").SpecificFeed;

--- a/FeedReader.Tests/FullParseTest.cs
+++ b/FeedReader.Tests/FullParseTest.cs
@@ -263,6 +263,10 @@ namespace CodeHollow.FeedReader.Tests
         }
 
         [TestMethod]
+        [Ignore]
+        // this test is invalid since RSS 2.0 feeds must follow the 
+        // http://www.faqs.org/rfcs/rfc822.html RFC822 for Date and Time formats
+        // therefore a date specified in german is not a valid date for an RSS feed
         public void TestRss20ParseContentWindGerman()
         {
             var feed = (Rss20Feed)FeedReader.ReadFromFile("Feeds/Rss20ContentWindCom.xml").SpecificFeed;

--- a/FeedReader.Tests/ItunesTest.cs
+++ b/FeedReader.Tests/ItunesTest.cs
@@ -1,0 +1,91 @@
+﻿using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using CodeHollow.FeedReader.Feeds.Itunes;
+using System.Linq;
+
+namespace CodeHollow.FeedReader.Tests
+{
+    [TestClass]
+    public class ItunesTest
+    {
+        private void Eq(object expected, object actual)
+        {
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestItunesSampleFeed()
+        {
+            var feed = FeedReader.ReadFromFile("Feeds/Rss20ItunesSample.xml");
+
+            var itunesChannel = feed.GetItunesChannel();
+
+            Eq("A show about everything", itunesChannel.Subtitle);
+            Eq("John Doe", itunesChannel.Author);
+            Eq("All About Everything is a show about everything. Each week we dive into any subject known to man and talk about it as much as we can. Look for our podcast in the Podcasts app or in the iTunes Store", itunesChannel.Summary);
+
+            Assert.IsNotNull(itunesChannel.Owner);
+            Eq("John Doe", itunesChannel.Owner.Name);
+            Eq("john.doe@example.com", itunesChannel.Owner.Email);
+            Assert.IsNotNull(itunesChannel.Image);
+            Eq("http://example.com/podcasts/everything/AllAboutEverything.jpg", itunesChannel.Image.Href);
+            Assert.IsNotNull(itunesChannel.Categories);
+            Eq("Technology", itunesChannel.Categories[0].Text);
+            Assert.IsNotNull(itunesChannel.Categories[0].Children);
+            Eq("Gadgets", itunesChannel.Categories[0].Children[0].Text);
+            Eq("TV & Film", itunesChannel.Categories[1].Text);
+            Eq("Arts", itunesChannel.Categories[2].Text);
+            Assert.IsNotNull(itunesChannel.Categories[2].Children);
+            Eq("Food", itunesChannel.Categories[2].Children[0].Text);
+            Eq(false, itunesChannel.Explicit);
+
+
+            var item1 = feed.Items.ElementAt(0).GetItunesItem();
+            var item2 = feed.Items.ElementAt(1).GetItunesItem();
+            var item3 = feed.Items.ElementAt(2).GetItunesItem();
+            var item4 = feed.Items.ElementAt(3).GetItunesItem();
+
+            Eq("John Doe", item1.Author);
+            Eq("A short primer on table spices", item1.Subtitle);
+            Eq("This week we talk about <a href=\"https://itunes/apple.com/us/book/antique-trader-salt-pepper/id429691295?mt=11\">salt and pepper shakers</a>, comparing and contrasting pour rates, construction materials, and overall aesthetics. Come and join the party!", item1.Summary);
+            Assert.IsNotNull(item1.Image);
+            Eq("http://example.com/podcasts/everything/AllAboutEverything/Episode1.jpg", item1.Image.Href);
+            Assert.IsNotNull(item1.Duration);
+            Eq(4, item1.Duration.Value.Seconds);
+            Eq(7, item1.Duration.Value.Minutes);
+            Eq(false, item1.Explicit);
+
+            Eq("Jane Doe", item2.Author);
+            Eq("Comparing socket wrenches is fun!", item2.Subtitle);
+            Eq("This week we talk about metric vs. Old English socket wrenches. Which one is better? Do you really need both? Get all of your answers here.", item2.Summary);
+            Assert.IsNotNull(item2.Image);
+            Eq("http://example.com/podcasts/everything/AllAboutEverything/Episode2.jpg", item2.Image.Href);
+            Assert.IsNotNull(item2.Duration);
+            Eq(34, item2.Duration.Value.Seconds);
+            Eq(4, item2.Duration.Value.Minutes);
+            Eq(false, item2.Explicit);
+
+            Eq("Jane Doe", item3.Author);
+            Eq("Jane and Eric", item3.Subtitle);
+            Eq("This week we talk about the best Chili in the world. Which chili is better?", item3.Summary);
+            Assert.IsNotNull(item3.Image);
+            Eq("http://example.com/podcasts/everything/AllAboutEverything/Episode3.jpg", item3.Image.Href);
+            Assert.IsNotNull(item3.Duration);
+            Eq(34, item3.Duration.Value.Seconds);
+            Eq(4, item3.Duration.Value.Minutes);
+            Eq(false, item3.Explicit);
+            Eq(true, item3.IsClosedCaptioned);
+
+            Eq("Various", item4.Author);
+            Eq("Red + Blue != Purple", item4.Subtitle);
+            Eq("This week we talk about surviving in a Red state if you are a Blue person. Or vice versa.", item4.Summary);
+            Assert.IsNotNull(item4.Image);
+            Eq("http://example.com/podcasts/everything/AllAboutEverything/Episode4.jpg", item4.Image.Href);
+            Assert.IsNotNull(item4.Duration);
+            Eq(59, item4.Duration.Value.Seconds);
+            Eq(3, item4.Duration.Value.Minutes);
+            Eq(false, item4.Explicit);
+
+        }
+    }
+}

--- a/FeedReader/FeedReader.cs
+++ b/FeedReader/FeedReader.cs
@@ -79,7 +79,6 @@
             return GetFeedUrlsFromUrlAsync(url).Result;
         }
 
-
         /// <summary>
         /// Opens a webpage and reads all feed urls from it (link rel="alternate" type="application/...")
         /// </summary>
@@ -99,7 +98,7 @@
         /// </summary>
         /// <param name="url">the url of the page</param>
         /// <returns>a list of links, an empty list if no links are found</returns>
-        [Obsolete("Use the ParseFeedUrlsAsString method")]
+        [Obsolete("Use the ParseFeedUrlsAsStringAsync method")]
         public static string[] ParseFeedUrlsAsString(string url)
         {
             return ParseFeedUrlsAsStringAsync(url).Result;

--- a/FeedReader/FeedReader.cs
+++ b/FeedReader/FeedReader.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Text.RegularExpressions;
+    using System.Threading.Tasks;
     using Parser;
 
     /// <summary>
@@ -72,10 +73,24 @@
         /// <returns>a list of links including the type and title, an empty list if no links are found</returns>
         /// <example>FeedReader.GetFeedUrlsFromUrl("codehollow.com"); // returns a list of all available feeds at 
         /// https://codehollow.com </example>
+        [Obsolete("Use GetFeedUrlsFromUrlAsync method")]
         public static IEnumerable<HtmlFeedLink> GetFeedUrlsFromUrl(string url)
         {
+            return GetFeedUrlsFromUrlAsync(url).Result;
+        }
+
+
+        /// <summary>
+        /// Opens a webpage and reads all feed urls from it (link rel="alternate" type="application/...")
+        /// </summary>
+        /// <param name="url">the url of the page</param>
+        /// <returns>a list of links including the type and title, an empty list if no links are found</returns>
+        /// <example>FeedReader.GetFeedUrlsFromUrl("codehollow.com"); // returns a list of all available feeds at 
+        /// https://codehollow.com </example>
+        public static async Task<IEnumerable<HtmlFeedLink>> GetFeedUrlsFromUrlAsync(string url)
+        {
             url = GetAbsoluteUrl(url);
-            string pageContent = Helpers.Download(url);
+            string pageContent = await Helpers.DownloadAsync(url);
             return ParseFeedUrlsFromHtml(pageContent);
         }
 
@@ -84,9 +99,20 @@
         /// </summary>
         /// <param name="url">the url of the page</param>
         /// <returns>a list of links, an empty list if no links are found</returns>
+        [Obsolete("Use the ParseFeedUrlsAsString method")]
         public static string[] ParseFeedUrlsAsString(string url)
         {
-            return GetFeedUrlsFromUrl(url).Select(x => x.Url).ToArray();
+            return ParseFeedUrlsAsStringAsync(url).Result;
+        }
+
+        /// <summary>
+        /// Opens a webpage and reads all feed urls from it (link rel="alternate" type="application/...")
+        /// </summary>
+        /// <param name="url">the url of the page</param>
+        /// <returns>a list of links, an empty list if no links are found</returns>
+        public static async Task<string[]> ParseFeedUrlsAsStringAsync(string url)
+        {
+            return (await GetFeedUrlsFromUrlAsync(url)).Select(x => x.Url).ToArray();
         }
         
         /// <summary>
@@ -131,9 +157,21 @@
         /// </summary>
         /// <param name="url">the url to a feed</param>
         /// <returns>parsed feed</returns>
+        [Obsolete("Use ReadAsync method")]
         public static Feed Read(string url)
         {
-            string feedContent = Helpers.Download(GetAbsoluteUrl(url));
+            return ReadAsync(url).Result;
+        }
+
+        /// <summary>
+        /// reads a feed from an url. the url must be a feed. Use ParseFeedUrlsFromHtml to
+        /// parse the feeds from a url which is not a feed.
+        /// </summary>
+        /// <param name="url">the url to a feed</param>
+        /// <returns>parsed feed</returns>
+        public static async Task<Feed> ReadAsync(string url)
+        {
+            string feedContent = await Helpers.DownloadAsync(GetAbsoluteUrl(url));
             return ReadFromString(feedContent);
         }
 
@@ -155,8 +193,7 @@
         /// <returns>parsed feed</returns>
         public static Feed ReadFromString(string feedContent)
         {
-            var feed = FeedParser.GetFeed(feedContent);
-            return feed;
+            return FeedParser.GetFeed(feedContent);
         }
         
         /// <summary>

--- a/FeedReader/Feeds/2.0/Rss20Feed.cs
+++ b/FeedReader/Feeds/2.0/Rss20Feed.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using System.Xml.Linq;
 
@@ -129,6 +130,28 @@
             this.PublishingDate = Helpers.TryParseDateTime(this.PublishingDateString);
             this.LastBuildDateString = channel.GetValue("lastBuildDate");
             this.LastBuildDate = Helpers.TryParseDateTime(this.LastBuildDateString);
+
+            if(this.Language != null && (this.PublishingDate == null || this.LastBuildDate == null))
+            {
+                CultureInfo culture = null;
+
+                try
+                {
+                    culture = new CultureInfo(this.Language);
+                    if (this.PublishingDate == null)
+                    {
+                        this.PublishingDate = Helpers.TryParseDateTime(this.PublishingDateString, culture);
+                    }
+
+                    if (this.LastBuildDate == null)
+                    {
+                        this.LastBuildDate = Helpers.TryParseDateTime(this.LastBuildDateString, culture);
+                    }
+                }
+                catch(CultureNotFoundException)
+                {
+                }
+            }
 
             var categories = channel.GetElements("category");
             this.Categories = categories.Select(x => x.GetValue()).ToList();

--- a/FeedReader/Feeds/Base/BaseFeed.cs
+++ b/FeedReader/Feeds/Base/BaseFeed.cs
@@ -1,6 +1,7 @@
 ﻿namespace CodeHollow.FeedReader.Feeds
 {
     using System.Collections.Generic;
+    using System.Xml.Linq;
 
     /// <summary>
     /// BaseFeed object which contains the basic properties that each feed has.
@@ -34,6 +35,11 @@
         public string OriginalDocument { get; private set; }
 
         /// <summary>
+        /// Gets the underlying XElement in order to allow reading properties that are not available in the class itself
+        /// </summary>
+        public XElement Element { get; }
+
+        /// <summary>
         /// default constructor (for serialization)
         /// </summary>
         public BaseFeed()
@@ -46,13 +52,14 @@
         /// </summary>
         /// <param name="feedXml"></param>
         /// <param name="xelement"></param>
-        public BaseFeed(string feedXml, System.Xml.Linq.XElement xelement)
+        public BaseFeed(string feedXml, XElement xelement)
             : this()
         {
             this.OriginalDocument = feedXml;
 
             this.Title = xelement.GetValue("title");
             this.Link = xelement.GetValue("link");
+            this.Element = xelement;
         }
     }
 }

--- a/FeedReader/Feeds/Base/BaseFeedItem.cs
+++ b/FeedReader/Feeds/Base/BaseFeedItem.cs
@@ -17,6 +17,11 @@
         /// </summary>
         public string Link { get; set; } // link
 
+        /// <summary>
+        /// Gets the underlying XElement in order to allow reading properties that are not available in the class itself
+        /// </summary>
+        public XElement Element { get; }
+
         internal abstract FeedItem ToFeedItem();
 
         /// <summary>
@@ -32,6 +37,7 @@
         {
             this.Title = item.GetValue("title");
             this.Link = item.GetValue("link");
+            this.Element = item;
         }
     }
 }

--- a/FeedReader/Feeds/Itunes/ItunesCategory.cs
+++ b/FeedReader/Feeds/Itunes/ItunesCategory.cs
@@ -1,0 +1,14 @@
+﻿namespace CodeHollow.FeedReader.Feeds.Itunes
+{
+    public class ItunesCategory
+    {
+        internal ItunesCategory(string text, ItunesCategory[] children)
+        {
+            Text = text;
+            Children = children;
+        }
+
+        public string Text { get; }
+        public ItunesCategory[] Children { get; }
+    }
+}

--- a/FeedReader/Feeds/Itunes/ItunesChannel.cs
+++ b/FeedReader/Feeds/Itunes/ItunesChannel.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace CodeHollow.FeedReader.Feeds.Itunes
+{
+    public class ItunesChannel
+    {
+        public ItunesChannel(XElement channelElement)
+        {
+
+            Author = channelElement.GetValue("itunes", "author");
+            Block = channelElement.GetValue("itunes", "block") == "Yes";
+            Categories = GetItunesCategories(channelElement);
+
+            var imageElement = channelElement.GetElement("itunes", "image");
+
+            if (imageElement != null)
+            {
+                Image = new ItunesImage(imageElement.GetAttributeValue("href"));
+            }
+
+            var explicitValue = channelElement.GetValue("itunes", "explicit");
+
+            Explicit = explicitValue == "Yes" || explicitValue == "Explicit" || explicitValue == "True";
+            Complete = channelElement.GetValue("itunes", "complete") == "Yes";
+
+            if (Uri.TryCreate(channelElement.GetValue("itunes", "new-feed-url"), UriKind.Absolute, out var newFeedUrl))
+            {
+                NewFeedUrl = newFeedUrl;
+            }
+
+            var ownerElement = channelElement.GetElement("itunes", "owner");
+
+            if(ownerElement != null)
+            {
+                Owner = new ItunesOwner(ownerElement.GetValue("itunes", "name"), ownerElement.GetValue("itunes", "email"));
+            }
+
+            Subtitle = channelElement.GetValue("itunes", "subtitle");
+            Summary = channelElement.GetValue("itunes", "summary");
+        }
+
+        public string Author { get; }
+        public bool Block { get; }
+        public ItunesCategory[] Categories { get; }
+        public ItunesImage Image { get; }
+        public bool Explicit { get; }
+        public bool Complete { get; }
+        public Uri NewFeedUrl { get; }
+        public ItunesOwner Owner { get; }
+        public string Subtitle { get; }
+        public string Summary { get; }
+
+        private ItunesCategory[] GetItunesCategories(XElement element)
+        {
+            var query = from categoryElement in element.GetElements("itunes", "category")
+                        let children = GetItunesCategories(categoryElement)
+                        select new ItunesCategory(categoryElement.GetAttributeValue("text"), children);
+
+            return query.ToArray();
+        }
+    }
+}

--- a/FeedReader/Feeds/Itunes/ItunesExtensions.cs
+++ b/FeedReader/Feeds/Itunes/ItunesExtensions.cs
@@ -1,0 +1,15 @@
+﻿namespace CodeHollow.FeedReader.Feeds.Itunes
+{
+    public static class ItunesExtensions
+    {
+        public static ItunesChannel GetItunesChannel(this Feed feed)
+        {
+            return new ItunesChannel(feed.SpecificFeed.Element);
+        }
+
+        public static ItunesItem GetItunesItem(this FeedItem item)
+        {
+            return new ItunesItem(item.SpecificItem.Element);
+        }
+    }
+}

--- a/FeedReader/Feeds/Itunes/ItunesImage.cs
+++ b/FeedReader/Feeds/Itunes/ItunesImage.cs
@@ -1,0 +1,12 @@
+﻿namespace CodeHollow.FeedReader.Feeds.Itunes
+{
+    public class ItunesImage
+    {
+        internal ItunesImage(string href)
+        {
+            Href = href;
+        }
+
+        public string Href { get; }
+    }
+}

--- a/FeedReader/Feeds/Itunes/ItunesItem.cs
+++ b/FeedReader/Feeds/Itunes/ItunesItem.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Xml.Linq;
+
+namespace CodeHollow.FeedReader.Feeds.Itunes
+{
+    public class ItunesItem
+    {
+        public ItunesItem(XElement itemElement)
+        {
+            Author = itemElement.GetValue("itunes", "author");
+            Block = itemElement.GetValue("itunes", "block") == "Yes";
+            var imageElement = itemElement.GetElement("itunes", "image");
+
+            if (imageElement != null)
+            {
+                Image = new ItunesImage(imageElement.GetAttributeValue("href"));
+            }
+
+            var duration = itemElement.GetValue("itunes", "duration");
+
+            if(duration != null)
+            {
+                try
+                {
+                    var durationArray = duration.Split(':');
+
+                    if (durationArray.Length == 1)
+                    {
+                        Duration = TimeSpan.FromSeconds(long.Parse(durationArray[0]));
+                    }
+                    else if (durationArray.Length == 2)
+                    {
+                        Duration = new TimeSpan(0, int.Parse(durationArray[0]), int.Parse(durationArray[1]));
+                    }
+                    else if (durationArray.Length == 3)
+                    {
+                        Duration = new TimeSpan(int.Parse(durationArray[0]), int.Parse(durationArray[1]), int.Parse(durationArray[2]));
+                    }
+                }
+                catch
+                {
+                }
+            }
+
+            var explicitValue = itemElement.GetValue("itunes", "explicit");
+            Explicit = explicitValue == "Yes" || explicitValue == "Explicit" || explicitValue == "True";
+
+            IsClosedCaptioned = itemElement.GetValue("itunes", "isClosedCaptioned") == "Yes";
+            
+            if(int.TryParse(itemElement.GetValue("itunes", "order"), out var order))
+            {
+                Order = order;
+            }
+
+            Subtitle = itemElement.GetValue("itunes", "subtitle");
+            Summary = itemElement.GetValue("itunes", "summary");
+        }
+
+        public string Author { get; }
+        public bool Block { get; }
+        public ItunesImage Image { get; }
+        public TimeSpan? Duration { get; }
+        public bool Explicit { get; }
+        public bool IsClosedCaptioned { get; }
+        public int Order { get; }
+        public string Subtitle { get; }
+        public string Summary { get; }
+    }
+}

--- a/FeedReader/Feeds/Itunes/ItunesOwner.cs
+++ b/FeedReader/Feeds/Itunes/ItunesOwner.cs
@@ -1,0 +1,14 @@
+﻿namespace CodeHollow.FeedReader.Feeds.Itunes
+{
+    public class ItunesOwner
+    {
+        internal ItunesOwner(string name, string email)
+        {
+            Name = name;
+            Email = email;
+        }
+
+        public string Email { get; }
+        public string Name { get; }
+    }
+}

--- a/FeedReader/Helpers.cs
+++ b/FeedReader/Helpers.cs
@@ -1,6 +1,7 @@
 ﻿namespace CodeHollow.FeedReader
 {
     using System;
+    using System.Globalization;
     using System.Net.Http;
     using System.Text;
     using System.Threading.Tasks;
@@ -60,13 +61,16 @@
         /// Tries to parse the string as datetime and returns null if it fails
         /// </summary>
         /// <param name="datetime">datetime as string</param>
+        /// <param name="cultureInfo">The cultureInfo for parsing</param>
         /// <returns>datetime or null</returns>
-        public static DateTime? TryParseDateTime(string datetime)
+        public static DateTime? TryParseDateTime(string datetime, CultureInfo cultureInfo = null)
         {
-            if (string.IsNullOrEmpty(datetime))
+            if (string.IsNullOrWhiteSpace(datetime))
                 return null;
-            DateTimeOffset dt;
-            if (!DateTimeOffset.TryParse(datetime, out dt))
+
+            var dateTimeFormat = cultureInfo?.DateTimeFormat ?? DateTimeFormatInfo.CurrentInfo;
+
+            if (!DateTimeOffset.TryParse(datetime, dateTimeFormat, DateTimeStyles.None, out var dt))
             {
                 // Do, 22 Dez 2016 17:36:00 +0000
                 // note - tried ParseExact with diff formats like "ddd, dd MMM yyyy hh:mm:ss K"
@@ -75,7 +79,7 @@
                     int pos = datetime.IndexOf(',') + 1;
                     string newdtstring = datetime.Substring(pos).Trim();
 
-                    DateTimeOffset.TryParse(newdtstring, out dt);
+                    DateTimeOffset.TryParse(newdtstring, dateTimeFormat, DateTimeStyles.None, out dt);
                 }
             }
 

--- a/FeedReader/Helpers.cs
+++ b/FeedReader/Helpers.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Net.Http;
+    using System.Text;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -9,44 +10,50 @@
     /// </summary>
     public static class Helpers
     {
+        private const string ACCEPT_HEADER_NAME = "Accept";
+        private const string ACCEPT_HEADER_VALUE = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8";
+        private const string USER_AGENT_NAME = "User-Agent";
+        private const string USER_AGENT_VALUE = "Mozilla/5.0 (Windows NT 6.3; rv:36.0) Gecko/20100101 Firefox/36.0";
+
+        // The HttpClient instance must be a static field
+        // https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/
+        private static readonly HttpClient _httpClient = new HttpClient();
+
         /// <summary>
         /// Download the content from an url
         /// </summary>
         /// <param name="url">correct url</param>
-        /// <returns>content as string</returns>
+        /// <returns>Content as string</returns>
+        [Obsolete("Use the DownloadAsync method")]
         public static string Download(string url)
+        {
+            return DownloadAsync(url).Result;
+        }
+
+        /// <summary>
+        /// Download the content from an url
+        /// </summary>
+        /// <param name="url">correct url</param>
+        /// <returns>Content as string</returns>
+        public static async Task<string> DownloadAsync(string url)
         {
             url = System.Net.WebUtility.UrlDecode(url);
 
-            using (var httpclient = new HttpClient())
+            using (var request = new HttpRequestMessage(HttpMethod.Get, url))
             {
-                //webclient.Encoding = System.Text.Encoding.UTF8; // TODO
-                // header required - without it, some pages return a bad request (e.g. http://www.methode.at/blog?format=RSS)
-                // see: https://msdn.microsoft.com/en-us/library/system.net.webclient(v=vs.110).aspx
-                httpclient.DefaultRequestHeaders.Add("user-agent", "Mozilla/5.0 (Windows NT 6.3; rv:36.0) Gecko/20100101 Firefox/36.0");
-                httpclient.DefaultRequestHeaders.Add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
-                
-                string result = string.Empty;
-                Task.Run(async () =>
-                    {
-                        var response = await httpclient.GetAsync(url);
-                        
-                        if(!response.IsSuccessStatusCode)
-                        {
-                            httpclient.DefaultRequestHeaders.Clear();
-                            // httpclient.Headers are now empty. Some pages return forbidden if user-agent is set.
-                            response = await httpclient.GetAsync(url);
-                        }
+                request.Headers.TryAddWithoutValidation(ACCEPT_HEADER_NAME, ACCEPT_HEADER_VALUE);
+                request.Headers.TryAddWithoutValidation(USER_AGENT_NAME, USER_AGENT_VALUE);
 
-                        // ReadAsByteArray avoids encoding issues that probably occur by using ReadAsStringAsync()
-                        //  - this issue is captured by testcase TestReadRss20FeedCharter97Handle403Forbidden
-                        var resultAsByteArray = await response.Content.ReadAsByteArrayAsync();
-                        result = System.Text.Encoding.UTF8.GetString(resultAsByteArray);
-                    }).Wait();
+                var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead);
 
-                return result;
+                if(!response.IsSuccessStatusCode)
+                {
+                    request.Headers.Clear();
+                    response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead);
+                }
+
+                return Encoding.UTF8.GetString(await response.Content.ReadAsByteArrayAsync());
             }
-
         }
 
         /// <summary>


### PR DESCRIPTION
- Added proper async methods for downloading the feed
- Fixed the usage of the HttpClient
- Exposed the XEelment on both BaseFeed and BaseFeedItem so the consumer of the library can access other elements than the ones provided, eg: itunes tags
- Added extension method for reading iTunes metadata Feed.GetItunesChannel() and FeedItem.GetItunesItem()