### PR TITLE
fix NPE when itunes namespace missing

### DIFF
--- a/FeedReader.Tests/FullParseTest.cs
+++ b/FeedReader.Tests/FullParseTest.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
 using CodeHollow.FeedReader.Feeds;
+using CodeHollow.FeedReader.Feeds.Itunes;
 
 namespace CodeHollow.FeedReader.Tests
 {
@@ -331,8 +332,19 @@ namespace CodeHollow.FeedReader.Tests
             {
                 var feed = FeedReader.ReadFromFile(file);
                 if (feed != null)
+                {
                     Assert.IsTrue(!string.IsNullOrEmpty(feed.Link));
+                    TestItunesParsingForException(feed);
+                }
             }
+        }
+
+        private static void TestItunesParsingForException(Feed feed)
+        {
+            Assert.IsNotNull(feed.GetItunesChannel());
+
+            foreach (var item in feed.Items)
+                Assert.IsNotNull(item.GetItunesItem());
         }
     }
 }

--- a/FeedReader/Feeds/Itunes/ItunesChannel.cs
+++ b/FeedReader/Feeds/Itunes/ItunesChannel.cs
@@ -104,9 +104,13 @@
         /// <returns>the itunes:categries</returns>
         private ItunesCategory[] GetItunesCategories(XElement element)
         {
-            var query = from categoryElement in element.GetElements(NAMESPACEPREFIX, "category")
-                        let children = GetItunesCategories(categoryElement)
-                        select new ItunesCategory(categoryElement.GetAttributeValue("text"), children);
+            var categoryElements = element.GetElements(NAMESPACEPREFIX, "category");
+            if (categoryElements == null)
+                return new ItunesCategory[0];
+
+            var query = from categoryElement in categoryElements
+                let children = GetItunesCategories(categoryElement)
+                select new ItunesCategory(categoryElement.GetAttributeValue("text"), children);
 
             return query.ToArray();
         }


### PR DESCRIPTION
Fix a NullPointerException being thrown when calling `item.GetItunesItem()`