### PR TITLE
Added support for Media RSS feed (www.rssboard.org/media-rss)

### DIFF
--- a/FeedReader.TestDataCrawler/FeedReader.TestDataCrawler.csproj
+++ b/FeedReader.TestDataCrawler/FeedReader.TestDataCrawler.csproj
@@ -33,9 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="HtmlAgilityPack, Version=1.4.9.5, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-      <HintPath>..\packages\HtmlAgilityPack.1.4.9.5\lib\Net45\HtmlAgilityPack.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="HtmlAgilityPack, Version=1.5.1.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\packages\HtmlAgilityPack.1.5.1\lib\Net45\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/FeedReader.TestDataCrawler/Program.cs
+++ b/FeedReader.TestDataCrawler/Program.cs
@@ -8,15 +8,21 @@ namespace CodeHollow.FeedReader.TestDataCrawler
     {
         static void Main(string[] args)
         {
-            var feeds = System.IO.File.ReadAllLines("feeds.txt");
-            Parallel.ForEach<string>(feeds, x =>
-            {
-                try
-                {
-                    Do(x);
-                }
-                catch { }
-            });
+
+
+            var contents = FeedReader.ReadAsync("https://www.telegraaf.nl/rss.xml").Result;
+
+            var x = contents.Items.Count;
+
+            //var feeds = System.IO.File.ReadAllLines("feeds.txt");
+            //Parallel.ForEach<string>(feeds, x =>
+            //{
+            //    try
+            //    {
+            //        Do(x);
+            //    }
+            //    catch { }
+            //});
             
         }
 

--- a/FeedReader.TestDataCrawler/Program.cs
+++ b/FeedReader.TestDataCrawler/Program.cs
@@ -9,21 +9,18 @@ namespace CodeHollow.FeedReader.TestDataCrawler
         static void Main(string[] args)
         {
 
+            var feeds = System.IO.File.ReadAllLines("feeds.txt");
+            Parallel.ForEach<string> (feeds, x =>
+               {
+                   try
+                   {
+                       Do(x);
+   
+                   }
+                   catch { }
+               }
+            );
 
-            var contents = FeedReader.ReadAsync("https://www.telegraaf.nl/rss.xml").Result;
-
-            var x = contents.Items.Count;
-
-            //var feeds = System.IO.File.ReadAllLines("feeds.txt");
-            //Parallel.ForEach<string>(feeds, x =>
-            //{
-            //    try
-            //    {
-            //        Do(x);
-            //    }
-            //    catch { }
-            //});
-            
         }
 
         static void Do(string url)
@@ -44,7 +41,7 @@ namespace CodeHollow.FeedReader.TestDataCrawler
                     var curl = FeedReader.GetAbsoluteFeedUrl(url, link);
 
                     string content = Helpers.DownloadAsync(curl.Url).Result;
-                    System.IO.File.WriteAllText("c:\\data\\feeds\\" + title + "_" + Guid.NewGuid().ToString() + ".xml", content);
+                    System.IO.File.WriteAllText("d:\\feeds\\" + title + "_" + Guid.NewGuid().ToString() + ".xml", content);
                     Console.Write("+");
                 }
                 catch (Exception ex)

--- a/FeedReader.TestDataCrawler/feeds.txt
+++ b/FeedReader.TestDataCrawler/feeds.txt
@@ -110,3 +110,4 @@ http://www.mn.ru/
 https://news.yandex.ru/Moscow
 http://massanews.com/
 http://www.trespassosnews.com.br/
+https://www.parool.nl/nieuws/rss.xml

--- a/FeedReader.TestDataCrawler/packages.config
+++ b/FeedReader.TestDataCrawler/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net452" />
+  <package id="HtmlAgilityPack" version="1.5.1" targetFramework="net452" />
 </packages>

--- a/FeedReader/FeedType.cs
+++ b/FeedReader/FeedType.cs
@@ -26,9 +26,15 @@
         Rss_1_0,
 
         /// <summary>
-        /// Rss 2.0 fedd
+        /// Rss 2.0 feed
         /// </summary>
         Rss_2_0,
+
+        /// <summary>
+        /// Media Rss feed
+        /// </summary>
+        MediaRss,
+
 
         /// <summary>
         /// Rss feed - is used for <see cref="HtmlFeedLink"/> type

--- a/FeedReader/Feeds/MediaRSS/Media.cs
+++ b/FeedReader/Feeds/MediaRSS/Media.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace CodeHollow.FeedReader.Feeds.MediaRSS
+{
+
+    /// <summary>
+    /// Media object
+    /// </summary>
+    public class Media
+    {
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Media"/> class.
+        /// Reads a rss feed item enclosure based on the xml given in element
+        /// </summary>
+        /// <param name="element">enclosure element as xml</param>
+        public Media(XElement element)
+        {
+            this.Url = element.GetAttributeValue("url");
+            this.FileSize = Helpers.TryParseInt(element.GetAttributeValue("fileSize"));
+            this.Type = element.GetAttributeValue("type");
+            this.Medium  = Helpers.TryParseMedium(element.GetAttributeValue("medium"));
+            this.isDefault = Helpers.TryParseBool(element.GetAttributeValue("isDefault"));
+            this.Duration = Helpers.TryParseInt(element.GetAttributeValue("duration"));
+            this.Height = Helpers.TryParseInt(element.GetAttributeValue("height"));
+            this.Width = Helpers.TryParseInt(element.GetAttributeValue("width"));
+            this.Language = element.GetAttributeValue("lang");
+
+            var thumbnails = element.GetElements("media", "thumbnail");
+            this.Thumbnails = thumbnails.Select(x => new Thumbnail(x)).ToList();
+
+        }
+
+        /// <summary>
+        /// The direct URL to the media object
+        /// </summary>
+        public string Url { get; set; }
+
+        /// <summary>
+        /// Number of bytes of the media object. Optional attribute
+        /// </summary>
+        public long? FileSize { get; set; }
+
+        /// <summary>
+        /// Standard MIME type of the object. Optional attribute
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Type of object. Optional attribute
+        /// </summary>
+        public Medium Medium { get; set; }
+
+
+        /// <summary>
+        /// Determines if this is the default object that should be used for the <see cref="MediaGroup"/>
+        /// </summary>
+        public bool? isDefault { get; set; }
+
+        /// <summary>
+        /// Number of seconds the media object plays. Optional attribute
+        /// </summary>
+        public int? Duration { get; set; }
+
+        /// <summary>
+        /// Height of the object media. Optional attribute
+        /// </summary>
+        public int? Height { get; set; }
+
+        /// <summary>
+        /// Width of the object media. Optional attribute
+        /// </summary>
+        public int? Width { get; set; }
+
+    
+        /// <summary>
+        /// The primary language encapsulated in the media object. Language codes possible are detailed in RFC 3066. This attribute is used similar to the xml:lang attribute detailed in the XML 1.0 Specification (Third Edition). It is an optional attribute.
+        /// </summary>
+        public string Language { get; set; }
+        
+        /// <summary>
+        /// Representative images for the media object
+        /// </summary>
+        public ICollection<Thumbnail> Thumbnails { get; set; }
+
+    }
+
+
+}

--- a/FeedReader/Feeds/MediaRSS/MediaGroup.cs
+++ b/FeedReader/Feeds/MediaRSS/MediaGroup.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace CodeHollow.FeedReader.Feeds.MediaRSS
+{
+
+    /// <summary>
+    /// A collection of media that are effectively the same content, yet different representations. For isntance: the same song recorded in both WAV and MP3 format.
+    /// </summary>
+    public class MediaGroup
+    {
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MediaGroup"/> class.
+        /// Reads a rss media group item enclosure based on the xml given in element
+        /// </summary>
+        /// <param name="element">enclosure element as xml</param>
+        public MediaGroup (XElement element)
+        {
+            var media = element.GetElements("media", "contents");
+            this.Media = media.Select(x => new Media(x)).ToList();
+        }
+
+        /// <summary>
+        /// Media object
+        /// </summary>
+        public ICollection<Media> Media { get; set; }
+
+    }
+}

--- a/FeedReader/Feeds/MediaRSS/MediaRssFeed.cs
+++ b/FeedReader/Feeds/MediaRSS/MediaRssFeed.cs
@@ -1,0 +1,234 @@
+﻿namespace CodeHollow.FeedReader.Feeds
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Xml.Linq;
+
+    /// <summary>
+    /// Media RSS 2.0 feed accoring to specification: http://www.rssboard.org/media-rss
+    /// </summary>
+    public class MediaRssFeed : BaseFeed
+    {
+        /// <summary>
+        /// The "description" element
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The "language" element
+        /// </summary>
+        public string Language { get; set; }
+
+        /// <summary>
+        /// The "copyright" element
+        /// </summary>
+        public string Copyright { get; set; }
+
+        /// <summary>
+        /// The "docs" element
+        /// </summary>
+        public string Docs { get; set; }
+
+        /// <summary>
+        /// The "image" element
+        /// </summary>
+        public FeedImage Image { get; set; }
+
+        /// <summary>
+        /// The "lastBuildDate" element as string
+        /// </summary>
+        public string LastBuildDateString { get; set; }
+
+        /// <summary>
+        /// The "lastBuildDate" element as DateTime. Null if parsing failed of lastBuildDate is empty.
+        /// </summary>
+        public DateTime? LastBuildDate { get; set; }
+
+        /// <summary>
+        /// The "managingEditor" element
+        /// </summary>
+        public string ManagingEditor { get; set; }
+
+        /// <summary>
+        /// The "pubDate" field
+        /// </summary>
+        public string PublishingDateString { get; set; }
+
+        /// <summary>
+        /// The "pubDate" field as DateTime. Null if parsing failed or pubDate is empty.
+        /// </summary>
+        public DateTime? PublishingDate { get; set; }
+
+        /// <summary>
+        /// The "webMaster" field
+        /// </summary>
+        public string WebMaster { get; set; }
+
+        /// <summary>
+        /// All "category" elements
+        /// </summary>
+        public ICollection<string> Categories { get; set; } // category
+
+        /// <summary>
+        /// The "generator" element
+        /// </summary>
+        public string Generator { get; set; }
+
+        /// <summary>
+        /// The "cloud" element
+        /// </summary>
+        public FeedCloud Cloud { get; set; }
+
+        /// <summary>
+        /// The time to life "ttl" element
+        /// </summary>
+        public string TTL { get; set; }
+
+        /// <summary>
+        /// All "day" elements in "skipDays"
+        /// </summary>
+        public ICollection<string> SkipDays { get; set; }
+
+        /// <summary>
+        /// All "hour" elements in "skipHours"
+        /// </summary>
+        public ICollection<string> SkipHours { get; set; }
+
+        /// <summary>
+        /// The "textInput" element
+        /// </summary>
+        public FeedTextInput TextInput { get; set; }
+
+        /// <summary>
+        /// All elements starting with "sy:"
+        /// </summary>
+        public Syndication Sy { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MediaRssFeed"/> class.
+        /// default constructor (for serialization)
+        /// </summary>
+        public MediaRssFeed()
+            : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MediaRssFeed"/> class.
+        /// Reads a Media Rss feed based on the xml given in channel
+        /// </summary>
+        /// <param name="feedXml">the entire feed xml as string</param>
+        /// <param name="channel">the "channel" element in the xml as XElement</param>
+        public MediaRssFeed(string feedXml, XElement channel)
+            : base(feedXml, channel)
+        {
+            this.Description = channel.GetValue("description");
+            this.Language = channel.GetValue("language");
+            this.Copyright = channel.GetValue("copyright");
+            this.ManagingEditor = channel.GetValue("managingEditor");
+            this.WebMaster = channel.GetValue("webMaster");
+            this.Docs = channel.GetValue("docs");
+            this.PublishingDateString = channel.GetValue("pubDate");
+            this.LastBuildDateString = channel.GetValue("lastBuildDate");
+            this.ParseDates(this.Language, this.PublishingDateString, this.LastBuildDateString);
+
+            var categories = channel.GetElements("category");
+            this.Categories = categories.Select(x => x.GetValue()).ToList();
+
+            this.Sy = new Syndication(channel);
+            this.Generator = channel.GetValue("generator");
+            this.TTL = channel.GetValue("ttl");
+            this.Image = new MediaRssFeedImage(channel.GetElement("image"));
+            this.Cloud = new FeedCloud(channel.GetElement("cloud"));
+            this.TextInput = new FeedTextInput(channel.GetElement("textinput"));
+
+            var skipHours = channel.GetElement("skipHours");
+            if (skipHours != null)
+                this.SkipHours = skipHours.GetElements("hour")?.Select(x => x.GetValue()).ToList();
+
+            var skipDays = channel.GetElement("skipDays");
+            if (skipDays != null)
+                this.SkipDays = skipDays.GetElements("day")?.Select(x => x.GetValue()).ToList();
+
+            var items = channel.GetElements("item");
+
+            foreach (var item in items)
+            {
+                this.Items.Add(new MediaRssFeedItem(item));
+            }
+        }
+
+        /// <summary>
+        /// Creates the base <see cref="Feed"/> element out of this feed.
+        /// </summary>
+        /// <returns>feed</returns>
+        public override Feed ToFeed()
+        {
+            Feed f = new Feed(this)
+            {
+                Copyright = this.Copyright,
+                Description = this.Description,
+                ImageUrl = this.Image?.Url,
+                Language = this.Language,
+                LastUpdatedDate = this.LastBuildDate,
+                LastUpdatedDateString = this.LastBuildDateString,
+                Type = FeedType.MediaRss
+            };
+            return f;
+        }
+
+        /// <summary>
+        /// Sets the PublishingDate and LastBuildDate. If parsing fails, then it checks if the language
+        /// is set and tries to parse the date based on the culture of the language.
+        /// </summary>
+        /// <param name="language">language of the feed</param>
+        /// <param name="publishingDate">publishing date as string</param>
+        /// <param name="lastBuildDate">last build date as string</param>
+        private void ParseDates(string language, string publishingDate, string lastBuildDate)
+        {
+            this.PublishingDate = Helpers.TryParseDateTime(publishingDate);
+            this.LastBuildDate = Helpers.TryParseDateTime(lastBuildDate);
+
+            // check if language is set - if so, check if dates could be parsed or try to parse it with culture of the language
+            if (string.IsNullOrWhiteSpace(language))
+                return;
+
+            // if publishingDateString is set but PublishingDate is null - try to parse with culture of "Language" property
+            bool parseLocalizedPublishingDate = this.PublishingDate == null && !string.IsNullOrWhiteSpace(this.PublishingDateString);
+
+            // if LastBuildDateString is set but LastBuildDate is null - try to parse with culture of "Language" property
+            bool parseLocalizedLastBuildDate = this.LastBuildDate == null && !string.IsNullOrWhiteSpace(this.LastBuildDateString);
+
+            // if both dates are set - return
+            if (!parseLocalizedPublishingDate && !parseLocalizedLastBuildDate)
+                return;
+
+            // dates are set, but one of them couldn't be parsed - so try again with the culture set to the language
+            CultureInfo culture = null;
+            try
+            {
+                culture = new CultureInfo(this.Language);
+            }
+            catch (CultureNotFoundException)
+            {
+                // should be replace by a try parse or by getting all cultures and selecting the culture
+                // out of the collection. That's unfortunately not available in .net standard 1.3 for now
+                // this case should never happen, but in some rare cases it does - so catching the exception
+                // is acceptable in that case.
+                return; // culture couldn't be found, return as it was already tried to parse with default values
+            }
+
+            if (parseLocalizedPublishingDate)
+            {
+                this.PublishingDate = Helpers.TryParseDateTime(this.PublishingDateString, culture);
+            }
+
+            if (parseLocalizedLastBuildDate)
+            {
+                this.LastBuildDate = Helpers.TryParseDateTime(this.LastBuildDateString, culture);
+            }
+        }
+    }
+}

--- a/FeedReader/Feeds/MediaRSS/MediaRssFeed.cs
+++ b/FeedReader/Feeds/MediaRSS/MediaRssFeed.cs
@@ -7,7 +7,7 @@
     using System.Xml.Linq;
 
     /// <summary>
-    /// Media RSS 2.0 feed accoring to specification: http://www.rssboard.org/media-rss
+    /// Media RSS 2.0 feed according to specification: http://www.rssboard.org/media-rss
     /// </summary>
     public class MediaRssFeed : BaseFeed
     {

--- a/FeedReader/Feeds/MediaRSS/MediaRssFeedImage.cs
+++ b/FeedReader/Feeds/MediaRSS/MediaRssFeedImage.cs
@@ -1,0 +1,29 @@
+﻿namespace CodeHollow.FeedReader.Feeds
+{
+    using System.Xml.Linq;
+
+    /// <summary>
+    /// Rss 2.0 Image according to specification: https://validator.w3.org/feed/docs/rss2.html#ltimagegtSubelementOfLtchannelgt
+    /// </summary>
+    public class MediaRssFeedImage : Rss091FeedImage
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MediaRssFeedImage"/> class.
+        /// default constructor (for serialization)
+        /// </summary>
+        public MediaRssFeedImage()
+            : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MediaRssFeedImage"/> class.
+        /// Reads a rss 2.0 feed image based on the xml given in element
+        /// </summary>
+        /// <param name="element">feed image as xml</param>
+        public MediaRssFeedImage(XElement element)
+            : base(element)
+        {
+        }
+    }
+}

--- a/FeedReader/Feeds/MediaRSS/MediaRssFeedItem.cs
+++ b/FeedReader/Feeds/MediaRSS/MediaRssFeedItem.cs
@@ -1,0 +1,135 @@
+﻿namespace CodeHollow.FeedReader.Feeds
+{
+    using CodeHollow.FeedReader.Feeds.MediaRSS;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Xml.Linq;
+
+    /// <summary>
+    /// RSS 2.0 feed item accoring to specification: https://validator.w3.org/feed/docs/rss2.html
+    /// </summary>
+    public class MediaRssFeedItem : BaseFeedItem
+    {
+        /// <summary>
+        /// The "description" field of the feed item
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The "author" field of the feed item
+        /// </summary>
+        public string Author { get; set; }
+
+        /// <summary>
+        /// The "comments" field of the feed item
+        /// </summary>
+        public string Comments { get; set; }
+
+        /// <summary>
+        /// The "enclosure" field
+        /// </summary>
+        public FeedItemEnclosure Enclosure { get; set; }
+
+        /// <summary>
+        /// The "guid" field
+        /// </summary>
+        public string Guid { get; set; }
+
+        /// <summary>
+        /// The "pubDate" field
+        /// </summary>
+        public string PublishingDateString { get; set; }
+
+        /// <summary>
+        /// The "pubDate" field as DateTime. Null if parsing failed or pubDate is empty.
+        /// </summary>
+        public DateTime? PublishingDate { get; set; }
+
+        /// <summary>
+        /// The "source" field
+        /// </summary>
+        public FeedItemSource Source { get; set; }
+
+        /// <summary>
+        /// All entries "category" entries
+        /// </summary>
+        public ICollection<string> Categories { get; set; }
+
+        /// <summary>
+        /// All entries from the "media:content" elements.
+        /// </summary>
+        public ICollection<Media> Media { get; set; }
+
+        /// <summary>
+        /// All entries from the "media:group" elements. 
+        /// </summary>
+        public ICollection<MediaGroup> MediaGroups { get; set; }
+
+        /// <summary>
+        /// The "content:encoded" field
+        /// </summary>
+        public string Content { get; set; }
+
+        /// <summary>
+        /// All elements starting with "dc:"
+        /// </summary>
+        public DublinCore DC { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MediaRssFeedItem"/> class.
+        /// default constructor (for serialization)
+        /// </summary>
+        public MediaRssFeedItem()
+            : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MediaRssFeedItem"/> class.
+        /// Reads a new feed item element based on the given xml item
+        /// </summary>
+        /// <param name="item">the xml containing the feed item</param>
+        public MediaRssFeedItem(XElement item)
+            : base(item)
+        {
+             
+            this.Comments = item.GetValue("comments");
+            this.Author = item.GetValue("author");
+            this.Enclosure = new FeedItemEnclosure(item.GetElement("enclosure"));
+            this.PublishingDateString = item.GetValue("pubDate");
+            this.PublishingDate = Helpers.TryParseDateTime(this.PublishingDateString);
+            this.DC = new DublinCore(item);
+            this.Source = new FeedItemSource(item.GetElement("source"));
+
+            var media = item.GetElements("media", "content");
+            this.Media = media.Select(x => new Media(x)).ToList();
+
+            var mediaGroups = item.GetElements("media", "group");
+            this.MediaGroups = mediaGroups.Select(x => new MediaGroup(x)).ToList();
+
+            var categories = item.GetElements("category");
+            this.Categories = categories.Select(x => x.GetValue()).ToList();
+
+            this.Guid = item.GetValue("guid");
+            this.Description = item.GetValue("description");
+            this.Content = item.GetValue("content:encoded")?.HtmlDecode();
+        }
+
+        /// <inheritdoc/>
+        internal override FeedItem ToFeedItem()
+        {
+            FeedItem fi = new FeedItem(this)
+            {
+                Author = this.Author,
+                Categories = this.Categories,
+                Content = this.Content,
+                Description = this.Description,
+                Id = this.Guid,
+                PublishingDate = this.PublishingDate,
+                PublishingDateString = this.PublishingDateString
+            };
+            return fi;
+        }
+    }
+}

--- a/FeedReader/Feeds/MediaRSS/Medium.cs
+++ b/FeedReader/Feeds/MediaRSS/Medium.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CodeHollow.FeedReader.Feeds.MediaRSS
+{
+    /// <summary>
+    /// Specifies the type of an object
+    /// </summary>
+    public enum Medium
+    {
+        /// <summary>
+        /// Image
+        /// </summary>
+        Image,
+
+        /// <summary>
+        /// Audio
+        /// </summary>
+        Audio,
+
+        /// <summary>
+        /// Video
+        /// </summary>
+        Video,
+
+        /// <summary>
+        /// Document
+        /// </summary>
+        Document,
+
+        /// <summary>
+        /// Executable
+        /// </summary>
+        Executable,
+
+        /// <summary>
+        /// Type could not be determined
+        /// </summary>
+        Unknown
+
+
+
+
+    }
+}

--- a/FeedReader/Feeds/MediaRSS/Thumbnail.cs
+++ b/FeedReader/Feeds/MediaRSS/Thumbnail.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml.Linq;
+
+namespace CodeHollow.FeedReader.Feeds.MediaRSS
+{
+
+    /// <summary>
+    /// Allows particular images to be used as representative images for the media object. If multiple thumbnails are included, and time coding is not at play, it is assumed that the images are in order of importance. 
+    /// </summary>
+    public class Thumbnail
+    {
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Thumbnail"/> class.
+        /// Reads a rss feed item enclosure based on the xml given in element
+        /// </summary>
+        /// <param name="element">enclosure element as xml</param>
+        public Thumbnail(XElement element)
+        {
+            this.Url = element.GetAttributeValue("url");
+            this.Height = Helpers.TryParseInt(element.GetAttributeValue("height"));
+            this.Width = Helpers.TryParseInt(element.GetAttributeValue("width"));
+            this.Time = element.GetAttributeValue("time");
+            
+        }
+
+        /// <summary>
+        /// The url of the thumbnail. Required attribute
+        /// </summary>
+        public string Url { get; set; }
+
+        /// <summary>
+        /// Height of the object media. Optional attribute
+        /// </summary>
+        public int? Height { get; set; }
+
+        /// <summary>
+        /// Width of the object media. Optional attribute
+        /// </summary>
+        public int? Width { get; set; }
+
+        /// <summary>
+        /// Specifies the time offset in relation to the media object
+        /// </summary>
+        public string Time { get; set; }
+
+    }
+}

--- a/FeedReader/Helpers.cs
+++ b/FeedReader/Helpers.cs
@@ -1,5 +1,6 @@
 ﻿namespace CodeHollow.FeedReader
 {
+    using CodeHollow.FeedReader.Feeds.MediaRSS;
     using System;
     using System.Globalization;
     using System.Net.Http;
@@ -101,5 +102,62 @@
                 return null;
             return tmp;
         }
+
+        /// <summary>
+        /// Tries to parse a string and returns the media type
+        /// </summary>
+        /// <param name="medium">media type as string</param>
+        /// <returns><see cref="Medium"/></returns>
+        public static Medium TryParseMedium (string medium)
+        {
+
+            if (string.IsNullOrEmpty(medium))
+            {
+                return Medium.Unknown;
+            }
+
+            switch (medium.ToLower()) {
+                case "image":
+                    return Medium.Image;
+                case "audio":
+                    return Medium.Audio;
+                case "video":
+                    return Medium.Video;
+                case "document":
+                    return Medium.Document;
+                case "executable":
+                    return Medium.Executable;
+                default:
+                    return Medium.Unknown;
+            }
+
+
+        }
+
+        /// <summary>
+        /// Tries to parse the string as int and returns null if it fails
+        /// </summary>
+        /// <param name="input">int as string</param>
+        /// <returns>integer or null</returns>
+        public static bool? TryParseBool(string input)
+        {
+            if (!string.IsNullOrEmpty(input))
+            {
+                input = input.ToLower();
+
+                if (input == "true")
+                {
+                    return true;
+                }
+                else if (input == "false")
+                {
+                    return false;
+                }
+            }
+            
+            return null;
+            
+        }
+
     }
 }

--- a/FeedReader/Parser/Factory.cs
+++ b/FeedReader/Parser/Factory.cs
@@ -10,6 +10,7 @@
                 case FeedType.Rss_0_91: return new Rss091Parser();
                 case FeedType.Rss_0_92: return new Rss092Parser();
                 case FeedType.Rss_1_0: return new Rss10Parser();
+                case FeedType.MediaRss: return new MediaRssParser();
                 default: return new Rss20Parser();
             }
         }

--- a/FeedReader/Parser/FeedParser.cs
+++ b/FeedReader/Parser/FeedParser.cs
@@ -16,7 +16,7 @@
         public static FeedType ParseFeedType(XDocument doc)
         {
             string rootElement = doc.Root.Name.LocalName;
-
+            
             if (rootElement.EqualsIgnoreCase("feed"))
                 return FeedType.Atom;
 
@@ -26,8 +26,13 @@
             if (rootElement.EqualsIgnoreCase("rss"))
             {
                 string version = doc.Root.Attribute("version").Value;
-                if (version.EqualsIgnoreCase("2.0"))
-                    return FeedType.Rss_2_0;
+                if (version.EqualsIgnoreCase("2.0")) {
+                    if (doc.Root.Attribute(XName.Get("media", XNamespace.Xmlns.NamespaceName)) != null) {
+                        return FeedType.MediaRss;
+                    } else {
+                        return FeedType.Rss_2_0;
+                    }
+                }
 
                 if (version.EqualsIgnoreCase("0.91"))
                     return FeedType.Rss_0_91;

--- a/FeedReader/Parser/MediaRssParser.cs
+++ b/FeedReader/Parser/MediaRssParser.cs
@@ -1,0 +1,16 @@
+﻿namespace CodeHollow.FeedReader.Parser
+{
+    using System.Xml.Linq;
+    using Feeds;
+
+    internal class MediaRssParser : AbstractXmlFeedParser
+    {
+        public override BaseFeed Parse(string feedXml, XDocument feedDoc)
+        {
+            var rss = feedDoc.Root;
+            var channel = rss.GetElement("channel");
+            MediaRssFeed feed = new MediaRssFeed(feedXml, channel);
+            return feed;
+        }
+    }
+}


### PR DESCRIPTION
I needed supported for the <media:content> and <media:group> tags that can be found in RSS feeds of many (dutch) newspaper RSS feeds and updated the library accordingly. Feel free to include the additions in the main project.