### PR TITLE
fix dublin core using for FeedItem.Author

### DIFF
--- a/FeedReader/Feeds/1.0/Rss10FeedItem.cs
+++ b/FeedReader/Feeds/1.0/Rss10FeedItem.cs
@@ -59,7 +59,7 @@
 
             if (this.DC != null)
             {
-                f.Author = this.DC.Publisher;
+                f.Author = this.DC.Creator;
                 f.Content = this.DC.Description;
                 f.PublishingDate = this.DC.Date;
                 f.PublishingDateString = this.DC.DateString;


### PR DESCRIPTION
According to Dublin Core Specifications Creator definition is: "An entity primarily responsible for making the resource." (http://dublincore.org/documents/dcmi-terms/#terms-creator).
But Publisher definition is "An entity responsible for making the resource available." (http://dublincore.org/documents/dcmi-terms/#terms-publisher).
It looks like Creator more suitable for FeedItem.Author then Publisher.