### PR TITLE
fix issue #6 with loading media content from a group

### DIFF
--- a/FeedReader/Feeds/MediaRSS/MediaGroup.cs
+++ b/FeedReader/Feeds/MediaRSS/MediaGroup.cs
@@ -20,7 +20,7 @@ namespace CodeHollow.FeedReader.Feeds.MediaRSS
         /// <param name="element">enclosure element as xml</param>
         public MediaGroup (XElement element)
         {
-            var media = element.GetElements("media", "contents");
+            var media = element.GetElements("media", "content");
             this.Media = media.Select(x => new Media(x)).ToList();
         }
 


### PR DESCRIPTION
fix as per definition of media:group on [http://www.rssboard.org/media-rss#media-group](url)

4.1. media:group
<media:group> is a sub-element of <item>. It allows grouping of **<media:content>** elements that are effectively the same content, yet different representations. For instance: the same song recorded in both the WAV and MP3 format. It's an optional element that must only be used for this purpose.