### PR TITLE
When using library in the UI application deadlocks are possible

### DIFF
--- a/FeedReader/FeedReader.cs
+++ b/FeedReader/FeedReader.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Text.RegularExpressions;
     using System.Threading.Tasks;
     using Parser;
 
@@ -89,7 +88,7 @@
         public static async Task<IEnumerable<HtmlFeedLink>> GetFeedUrlsFromUrlAsync(string url, bool autoRedirect = true)
         {
             url = GetAbsoluteUrl(url);
-            string pageContent = await Helpers.DownloadAsync(url, autoRedirect);
+            string pageContent = await Helpers.DownloadAsync(url, autoRedirect).ConfigureAwait(false);
             var links = ParseFeedUrlsFromHtml(pageContent);
             return links;
         }
@@ -112,7 +111,7 @@
         /// <returns>a list of links, an empty list if no links are found</returns>
         public static async Task<string[]> ParseFeedUrlsAsStringAsync(string url)
         {
-            return (await GetFeedUrlsFromUrlAsync(url)).Select(x => x.Url).ToArray();
+            return (await GetFeedUrlsFromUrlAsync(url).ConfigureAwait(false)).Select(x => x.Url).ToArray();
         }
 
         /// <summary>
@@ -176,7 +175,7 @@
         /// <returns>parsed feed</returns>
         public static async Task<Feed> ReadAsync(string url, bool autoRedirect = true)
         {
-            string feedContent = await Helpers.DownloadAsync(GetAbsoluteUrl(url), autoRedirect);
+            string feedContent = await Helpers.DownloadAsync(GetAbsoluteUrl(url), autoRedirect).ConfigureAwait(false);
             return ReadFromString(feedContent);
         }
 

--- a/FeedReader/Helpers.cs
+++ b/FeedReader/Helpers.cs
@@ -1,6 +1,6 @@
 ﻿namespace CodeHollow.FeedReader
 {
-    using CodeHollow.FeedReader.Feeds.MediaRSS;
+    using Feeds.MediaRSS;
     using System;
     using System.Globalization;
     using System.Net.Http;
@@ -47,7 +47,7 @@
                 request.Headers.TryAddWithoutValidation(ACCEPT_HEADER_NAME, ACCEPT_HEADER_VALUE);
                 request.Headers.TryAddWithoutValidation(USER_AGENT_NAME, USER_AGENT_VALUE);
 
-                response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead);
+                response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead).ConfigureAwait(false);
             }
             if (!response.IsSuccessStatusCode)
             {
@@ -58,11 +58,11 @@
 
                 using (var request = new HttpRequestMessage(HttpMethod.Get, url))
                 {
-                    response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead);
+                    response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead).ConfigureAwait(false);
                 }
             }
 
-            return Encoding.UTF8.GetString(await response.Content.ReadAsByteArrayAsync());
+            return Encoding.UTF8.GetString(await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false));
         }
 
         /// <summary>


### PR DESCRIPTION
When using library in the UI application deadlocks are possible. All async calls should have ConfigureAwaite(false)