### PR TITLE
Change Feed.Items to IList<FeedItem> to enable more iteration options

### DIFF
--- a/FeedReader/Feed.cs
+++ b/FeedReader/Feed.cs
@@ -63,7 +63,7 @@
         /// <summary>
         /// List of items
         /// </summary>
-        public ICollection<FeedItem> Items { get; set; }
+        public IList<FeedItem> Items { get; set; }
 
         /// <summary>
         /// Gets the whole, original feed as string


### PR DESCRIPTION
The underlying type is List\<FeedItem\> so this has no effect on the deserialization of the Feed. Furthermore, IList is a superset of ICollection, so existing users of the library should be unaffected.