### PR TITLE
Add a method to set HttpClient timeout

### DIFF
--- a/FeedReader/FeedReader.cs
+++ b/FeedReader/FeedReader.cs
@@ -22,7 +22,7 @@
     /// </example>
     public static class FeedReader
     {
-#if NETSTANDARD1_1_OR_GREATER || NETCOREAPP1_0_OR_GREATER
+#if NETSTANDARD1_1_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET45_OR_GREATER
         /// <summary>
         /// Set a timeout for reading feeds
         /// </summary>

--- a/FeedReader/FeedReader.cs
+++ b/FeedReader/FeedReader.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
     using Parser;
@@ -21,6 +22,16 @@
     /// </example>
     public static class FeedReader
     {
+#if NETSTANDARD1_1_OR_GREATER || NETCOREAPP1_0_OR_GREATER
+        /// <summary>
+        /// Set a timeout for reading feeds
+        /// </summary>
+        public static void SetTimeout(TimeSpan timeout)
+        {
+            Helpers.SetTimeout(timeout);
+        }
+#endif
+
         /// <summary>
         /// gets a url (with or without http) and returns the full url
         /// </summary>

--- a/FeedReader/Helpers.cs
+++ b/FeedReader/Helpers.cs
@@ -30,7 +30,7 @@
             }
         );
 
-#if NETSTANDARD1_1_OR_GREATER || NETCOREAPP1_0_OR_GREATER
+#if NETSTANDARD1_1_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET45_OR_GREATER
         internal static void SetTimeout(TimeSpan timeout)
         {
             _httpClient.Timeout = timeout;

--- a/FeedReader/Helpers.cs
+++ b/FeedReader/Helpers.cs
@@ -30,6 +30,16 @@
             }
         );
 
+#if NETSTANDARD1_1_OR_GREATER || NETCOREAPP1_0_OR_GREATER
+        /// <summary>
+        /// Set a timeout for http calls
+        /// </summary>
+        public static void SetTimeout(TimeSpan timeout)
+        {
+            _httpClient.Timeout = timeout;
+        }
+#endif
+
         /// <summary>
         /// Download the content from an url
         /// </summary>

--- a/FeedReader/Helpers.cs
+++ b/FeedReader/Helpers.cs
@@ -31,10 +31,7 @@
         );
 
 #if NETSTANDARD1_1_OR_GREATER || NETCOREAPP1_0_OR_GREATER
-        /// <summary>
-        /// Set a timeout for http calls
-        /// </summary>
-        public static void SetTimeout(TimeSpan timeout)
+        internal static void SetTimeout(TimeSpan timeout)
         {
             _httpClient.Timeout = timeout;
         }


### PR DESCRIPTION
Sometimes feeds don't return a response for too long, or don't respond in the expected amount of time. 

This change aims to fix that unpredictability for frameworks supporting `HttpClient.Timeout` and `TimeSpan`.